### PR TITLE
Add onFile option to add handler to directly handle files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Designed for use with [Koa2](https://github.com/koajs/koa/tree/v2.x) and [Async/
 
 ## Examples
 
-### Async/Await
+#### Async/Await (using temp files)
 ```js
 import asyncBusboy from 'async-busboy';
 
@@ -37,8 +37,26 @@ async function(ctx, next) {
   }
 }
 ```
+#### Async/Await (using custom onFile handler, i.e. no temp files)
+```js
+import asyncBusboy from 'async-busboy';
 
-### ES5 with promise
+// Koa 2 middleware
+async function(ctx, next) {
+  const {fields} = await asyncBusboy(ctx.req, {
+    onFile: function(fieldname, file, filename, encoding, mimetype) {
+        uploadFilesToS3(file);
+    }
+  });
+
+  // Do validation, but file is already uploaded...
+  if ( !checkFiles(fields) ) {
+    return 'error';
+  }
+}
+```
+
+#### ES5 with promise (using temp files)
 ```js
 var asyncBusboy = require('async-busboy');
 
@@ -49,7 +67,15 @@ function(someHTTPRequest) {
   });
 }
 ```
-As of today there is no support for directly piping of the request stream into a consumer. The files are first written to disk using `os.tmpdir()`. When the consumer stream drained the request stream, files will be automatically removed, otherwise the host OS should take care of the cleaning process.
+
+As of today there is no support for directly piping of the request stream into a consumer when using the standard API. The files are first written to disk using `os.tmpdir()`. When the consumer stream drained the request stream, files will be automatically removed, otherwise the host OS should take care of the cleaning process.
+
+If a custom onFile handler is specified in the options to async-busboy it
+will only resolve an object containing fields, but instead no temporary files
+needs to be created since the file stream is directly passed to the application.
+Note that all file streams need to be consumed for async-busboy to resolve due
+to the implementation of busboy. If a you don't care about a received
+file stream, simply call `stream.resume();` to discard the content.
 
 ## Working with nested inputs and objects
 Make sure to serialize objects before sending them as formData.
@@ -106,7 +132,7 @@ const serializeFormData = (obj, formDataObj, namespace = null) => {
 
 
 ### Try it on your local
-If you want to run some test localy, clone this repo, then run: `node examples/index.js`
+If you want to run some test locally, clone this repo, then run: `node examples/index.js`
 From there you can use something like [Postman](https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop?hl=en) to send `POST` request to `localhost:8080`.
 Note: When using Postman make sure to not send a `Content-Type` header, if it's filed by default, just delete it. (This is to let the `boudary` header be generated automaticaly)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Designed for use with [Koa2](https://github.com/koajs/koa/tree/v2.x) and [Async/
 
 ## Examples
 
-#### Async/Await (using temp files)
+### Async/Await (using temp files)
 ```js
 import asyncBusboy from 'async-busboy';
 
@@ -37,7 +37,7 @@ async function(ctx, next) {
   }
 }
 ```
-#### Async/Await (using custom onFile handler, i.e. no temp files)
+### Async/Await (using custom onFile handler, i.e. no temp files)
 ```js
 import asyncBusboy from 'async-busboy';
 
@@ -56,7 +56,7 @@ async function(ctx, next) {
 }
 ```
 
-#### ES5 with promise (using temp files)
+### ES5 with promise (using temp files)
 ```js
 var asyncBusboy = require('async-busboy');
 
@@ -68,14 +68,16 @@ function(someHTTPRequest) {
 }
 ```
 
-As of today there is no support for directly piping of the request stream into a consumer when using the standard API. The files are first written to disk using `os.tmpdir()`. When the consumer stream drained the request stream, files will be automatically removed, otherwise the host OS should take care of the cleaning process.
+## Async API using temp files
+The request streams are first written to temporary files using `os.tmpdir()`. File read streams associated with the temporary files are returned from the call to async-busboy. When the consumer has drained the file read streams, the files will be automatically removed, otherwise the host OS should take care of the cleaning process.
 
+## Async API using custom onFile handler
 If a custom onFile handler is specified in the options to async-busboy it
 will only resolve an object containing fields, but instead no temporary files
 needs to be created since the file stream is directly passed to the application.
 Note that all file streams need to be consumed for async-busboy to resolve due
-to the implementation of busboy. If a you don't care about a received
-file stream, simply call `stream.resume();` to discard the content.
+to the implementation of busboy. If you don't care about a received
+file stream, simply call `stream.resume()` to discard the content.
 
 ## Working with nested inputs and objects
 Make sure to serialize objects before sending them as formData.

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ const getDescriptor = Object.getOwnPropertyDescriptor;
 module.exports = function (request, options) {
   options = options || {};
   options.headers = request.headers;
+  const customOnFile = typeof options.onFile === "function" ? options.onFile : false;
+  delete options.onFile;
   const busboy = new Busboy(options);
 
   return new Promise((resolve, reject) => {
@@ -20,7 +22,7 @@ module.exports = function (request, options) {
 
     busboy
       .on('field', onField.bind(null, fields))
-      .on('file', onFile.bind(null, filePromises))
+      .on('file', customOnFile || onFile.bind(null, filePromises))
       .on('close', cleanup)
       .on('error', onError)
       .on('end', onEnd)
@@ -55,13 +57,20 @@ module.exports = function (request, options) {
     }
 
     function onEnd(err) {
-      if(err) reject(err);
-      Promise.all(filePromises)
-        .then((files) => {
+      if(err) {
+          return reject(err);
+      }
+      if (customOnFile) {
           cleanup();
-          resolve({fields, files});
-        })
-        .catch(reject);
+          resolve({ fields });
+      } else {
+          Promise.all(filePromises)
+            .then((files) => {
+              cleanup();
+              resolve({fields, files});
+            })
+            .catch(reject);
+        }
     }
 
     function cleanup() {


### PR DESCRIPTION
When using a custom onFile handler, the promise returned by async-busboy
only resolves to an object containing fields. The advantage is that no
intermediate temp files needs to be stored on disk!

The changes is backward-compatible with the previous API and adds a new API in order to get rid of the need to store temp files.

Basically, if you need performance and/or disk-space is scarce, use new API. If you want simplicity, use old API.

See updated README.md or testcase for example...

What do you think? Discuss!