### PR TITLE
Uses uuid in temp file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const Busboy = require('busboy');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const uuidV4 = require('uuid/v4');
 
 const getDescriptor = Object.getOwnPropertyDescriptor;
 
@@ -93,7 +94,7 @@ function onField(fields, name, val, fieldnameTruncated, valTruncated) {
 }
 
 function onFile(filePromises, fieldname, file, filename, encoding, mimetype) {
-  const tmpName = file.tmpName = new Date().getTime()  + fieldname  + filename;
+  const tmpName = file.tmpName = uuidV4() + '-' + filename;
   const saveTo = path.join(os.tmpdir(), path.basename(tmpName));
   const writeStream = fs.createWriteStream(saveTo);
   const filePromise = new Promise((resolve, reject) => writeStream

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const Busboy = require('busboy');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const uuidV4 = require('uuid/v4');
 
 const getDescriptor = Object.getOwnPropertyDescriptor;
 
@@ -94,7 +93,7 @@ function onField(fields, name, val, fieldnameTruncated, valTruncated) {
 }
 
 function onFile(filePromises, fieldname, file, filename, encoding, mimetype) {
-  const tmpName = file.tmpName = uuidV4() + '-' + filename;
+  const tmpName = file.tmpName = Math.random().toString(16).substring(2) + '-' + filename;
   const saveTo = path.join(os.tmpdir(), path.basename(tmpName));
   const writeStream = fs.createWriteStream(saveTo);
   const filePromise = new Promise((resolve, reject) => writeStream

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   "author": "Emanuel Chappat <emmanuel.chappat@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "busboy": "^0.2.12",
-    "uuid": "^3.0.1"
+    "busboy": "^0.2.12"
   },
   "devDependencies": {
     "expect": "^1.13.4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "author": "Emanuel Chappat <emmanuel.chappat@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "busboy": "^0.2.12"
+    "busboy": "^0.2.12",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "expect": "^1.13.4",


### PR DESCRIPTION
This way there will be no collisions in file names if the same request is made in a short (< 1 ms) amount of time (for instance when running load tests).