### PR TITLE
Updated docs about custom onFile handler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ import asyncBusboy from 'async-busboy';
 
 // Koa 2 middleware
 async function(ctx, next) {
-  const {fields} = await asyncBusboy(ctx.req, {
-    onFile: function(filePromises, fieldname, file, filename, encoding, mimetype) {
-        uploadFilesToS3(file);
+  const { fields } = await asyncBusboy(ctx.req, {
+    onFile: function(fieldname, file, filename, encoding, mimetype) {
+      uploadFilesToS3(file);
     }
   });
 
-  // Do validation, but file is already uploaded...
+  // Do validation, but files are already uploading...
   if ( !checkFiles(fields) ) {
     return 'error';
   }


### PR DESCRIPTION
This addresses #29, where the documentation for `onFile` is incorrect - [`filePromises` are not passed as an arg to a custom `onFile` handler](https://github.com/m4nuC/async-busboy/blob/master/index.js#L25).

---

Happy to add documentation for how to add a custom `filePromises`, however I felt that this may overcomplicate/confuse initial readers - thoughts?

```js
async function(ctx, next) {
  const files = []
  const { fields } = await asyncBusboy(ctx.req, {
    onFile: function(fieldname, file, filename, encoding, mimetype) {
      files.push(uploadFilesToS3(file));
    }
  });

  const uploads = await Promise.all(files)
  if ( !validate(fields, uploads) ) {
    return 'error';
  }
}
```


